### PR TITLE
Notification Protocol

### DIFF
--- a/src/nodeserver/api/instance/actions/conn_actions.py
+++ b/src/nodeserver/api/instance/actions/conn_actions.py
@@ -2,6 +2,7 @@ from nodeserver.api.instance.actions.action_controller import Action
 from nodeserver.api.internal.internal_protocols import InstanceProtocol
 from nodeserver.api.web.requests.action_requests import ConnectionActionAddUpdate, ConnectionActionRemove
 from nodeserver.api.web.requests.client_requests import MsgConnectionAction
+from nodeserver.api.web.requests.notification_requests import NotificationLevel, ServerNotification
 from nodeserver.api.web.websocket_protocol import EditorActionStatus
 
 class ConnActionUtils:
@@ -16,14 +17,20 @@ class ConnActionUtils:
             for conn_uid, conn_data in payload.action_data.items():
                 conn_data.uid = conn_uid
                 instance.mirror_manager.add_conn_mirror(conn_data)
-            
+
+                instance.send_to_client(ServerNotification.conn_notify(
+                    conn_uid=conn_uid,
+                    message="Added connection",
+                    level=NotificationLevel.DEBUG
+                ))
+
             instance._scene.update_nodes()
             return EditorActionStatus.SUCCESSFULL
 
         elif isinstance(payload, ConnectionActionRemove):
             if not payload.uids:
                 return EditorActionStatus.FAILED
-                
+            
             instance.mirror_manager.remove_conn_mirror(payload.uids)
             instance._scene.update_nodes()
             return EditorActionStatus.SUCCESSFULL

--- a/src/nodeserver/api/instance/actions/node_actions.py
+++ b/src/nodeserver/api/instance/actions/node_actions.py
@@ -1,7 +1,9 @@
 from nodeserver.api.instance.actions.action_controller import Action
+from nodeserver.api.instance.base_nodes import BaseNode
 from nodeserver.api.internal.internal_protocols import InstanceProtocol
 from nodeserver.api.web.requests.action_requests import NodeActionAddUpdate, NodeActionRemove
 from nodeserver.api.web.requests.client_requests import MsgNodeAction
+from nodeserver.api.web.requests.notification_requests import NotificationLevel, ServerNotification
 from nodeserver.api.web.websocket_protocol import EditorActionStatus, SceneActionTypes
 
 class NodeActionUtils:
@@ -47,7 +49,7 @@ class NodeActionUtils:
     
     @staticmethod
     def _node_add(payload: NodeActionAddUpdate, instance: InstanceProtocol) -> EditorActionStatus:
-        nodes = []
+        nodes: list[BaseNode] = []
         for node_uid, node_data in payload.action_data.items():
             node_data.uid = node_uid
             mirror = instance.mirror_manager.add_node_mirror(node_data, node_uid)
@@ -57,6 +59,16 @@ class NodeActionUtils:
             node = instance._scene.build_node(mirror)
             if node:
                 nodes.append(node)
+
+        # FIXME
+        for node in nodes:
+            is_fine = node.self_validate(instance._scene.mirror_manager.node_manager, instance._scene.mirror_manager.connection_manager)
+            if not is_fine:
+                instance.send_to_client(ServerNotification.node_notify(
+                    message="Something went wrong with this guy idk",
+                    level=NotificationLevel.ERROR,
+                    node_uid=node._mirror.uid
+                ))
 
         instance._scene.add_nodes(nodes)
         instance._scene.update_nodes()

--- a/src/nodeserver/api/instance/actions/node_actions.py
+++ b/src/nodeserver/api/instance/actions/node_actions.py
@@ -69,6 +69,13 @@ class NodeActionUtils:
                     level=NotificationLevel.ERROR,
                     node_uid=node._mirror.uid
                 ))
+                continue
+
+            instance.send_to_client(ServerNotification.node_notify(
+                node._mirror.uid,
+                message=f"Added node of type {node._mirror.type_name}",
+                level=NotificationLevel.DEBUG
+            ))
 
         instance._scene.add_nodes(nodes)
         instance._scene.update_nodes()

--- a/src/nodeserver/api/instance/base_nodes.py
+++ b/src/nodeserver/api/instance/base_nodes.py
@@ -6,6 +6,8 @@ from typing import Any, Optional
 
 from nodeserver.api.internal.instance_state import InternalNodeState
 from nodeserver.wrapper.nodes.data.node_data_types import SuperSlotTypes
+from nodeserver.wrapper.nodes.helpers.connection_manager import ConnectionManager
+from nodeserver.wrapper.nodes.helpers.node_manager import NodeMirrorManager
 from nodeserver.wrapper.nodes.node.base_nodes import NodeMirror, SlotMirror, SlotOutput
 
 # TODO: Change node inputs to a NodeOutput class or NodeInputs class
@@ -54,6 +56,9 @@ class BaseNode:
 
         return output_map
 
+    def self_validate(self, node_manager: NodeMirrorManager, conn_manager: ConnectionManager) -> bool:
+        return True
+
     # Override these on your Node class:
     # Your load state logic
     def load_state(self, root_state_path: str, state: InternalNodeState):
@@ -87,3 +92,4 @@ class BaseNode:
     def make_state_file_path(self, root_path: str, extension: str) -> tuple[str, str]:
         filename = f"{self._mirror.uid}.{extension}"
         return os.path.join(root_path, filename), filename
+    

--- a/src/nodeserver/api/instance/server_instance.py
+++ b/src/nodeserver/api/instance/server_instance.py
@@ -7,6 +7,7 @@ from nodeserver.api.instance.actions.node_actions import NodeActionUtils
 from nodeserver.api.instance.base_nodes import BaseNode, SlotOutput
 from nodeserver.api.instance.instance_states import InstanceCommands, InstanceStates, LoopStates, StateController
 from nodeserver.api.internal.instance_state import InstanceState, InternalNodeState, InternalState, StateFileUtils
+from nodeserver.api.internal.internal_protocols import InstanceProtocol
 from nodeserver.api.web.requests.notification_requests import NotificationLevel, ServerNotification
 from nodeserver.api.web.requests.websocket_requests import ServerMessage, SrvNodeOutput, SrvSyncAction, SrvSyncState, SyncStatePayload
 from nodeserver.api.web.websocket_protocol import ClientMessages, EditorActionStatus
@@ -36,7 +37,7 @@ class BaseServerRuntime:
         self._node_execution_cache = {}
 
         
-    def process_next(self, node_scene: NodeScene) -> tuple[dict[SlotMirror, SlotOutput] | None, BaseNode, bool] | None:
+    def process_next(self, node_scene: NodeScene, instance_protocol: InstanceProtocol) -> tuple[dict[SlotMirror, SlotOutput] | None, BaseNode, bool] | None:
         if self._current_idx == None or not self._process_order:
             return None
         
@@ -84,20 +85,28 @@ class BaseServerRuntime:
             }
             return (cached_outputs, current_node, True)
 
-        node_result = current_node.forward(node_inputs)
-        output_data: dict[SlotMirror, SlotOutput] = {}
-        for slot in node_result:
-            if slot.type._super_type != SuperSlotTypes.OUTPUT:
-                logger.error(f"ERROR: Outputs should always come from an Output slot | Slot: {slot} | Node: {current_node}")
-            
-            slot_output = node_result[slot]
+        try:
+            node_result = current_node.forward(node_inputs)
+            output_data: dict[SlotMirror, SlotOutput] = {}
+            for slot in node_result:
+                if slot.type._super_type != SuperSlotTypes.OUTPUT:
+                    logger.error(f"ERROR: Outputs should always come from an Output slot | Slot: {slot} | Node: {current_node}")
+                
+                slot_output = node_result[slot]
 
-            output_data[slot] = slot_output
-            self._output_cache[slot] = slot_output
-        
-        current_node.post_forward()
-        self._node_execution_cache[current_node._mirror.uid] = context_version
-        return (output_data, current_node, False)
+                output_data[slot] = slot_output
+                self._output_cache[slot] = slot_output
+            
+            current_node.post_forward()
+            self._node_execution_cache[current_node._mirror.uid] = context_version
+            return (output_data, current_node, False)
+        except Exception as e:
+            instance_protocol.send_to_client(ServerNotification.node_notify(
+                node_uid=current_node._mirror.uid,
+                message="Something went wrong",
+                level=NotificationLevel.ERROR,
+                description=str(e)
+            ))
 
     def continue_process(self, scene: NodeScene):
         self.waiting_to_continue = False
@@ -172,7 +181,7 @@ class ServerInstance:
 
             self.state_controller.has_step_permission = False
 
-        results = self._runtime.process_next(self._scene)
+        results = self._runtime.process_next(self._scene, self)
         if results != None:
             slot_results, node, came_from_cache = results
             result_data = self._prepare_to_send_output(node, slot_results)
@@ -182,7 +191,6 @@ class ServerInstance:
                 node_id=node._mirror.uid,
                 value=result_data
             ))
-            
         logger.info("DEBUG: Running server instance")
 
 
@@ -309,7 +317,7 @@ class ServerInstance:
         # FIXME: Testing notifications:
         self.send_to_client(ServerNotification.notify(
             message="State changed!",
-            level=NotificationLevel.INFO
+            level=NotificationLevel.DEBUG
         ))
 
 

--- a/src/nodeserver/api/instance/server_instance.py
+++ b/src/nodeserver/api/instance/server_instance.py
@@ -7,6 +7,7 @@ from nodeserver.api.instance.actions.node_actions import NodeActionUtils
 from nodeserver.api.instance.base_nodes import BaseNode, SlotOutput
 from nodeserver.api.instance.instance_states import InstanceCommands, InstanceStates, LoopStates, StateController
 from nodeserver.api.internal.instance_state import InstanceState, InternalNodeState, InternalState, StateFileUtils
+from nodeserver.api.web.requests.notification_requests import NotificationLevel, ServerNotification
 from nodeserver.api.web.requests.websocket_requests import ServerMessage, SrvNodeOutput, SrvSyncAction, SrvSyncState, SyncStatePayload
 from nodeserver.api.web.websocket_protocol import ClientMessages, EditorActionStatus
 from nodeserver.api.instance.node_scene import NodeScene
@@ -16,6 +17,7 @@ from nodeserver.wrapper.nodes.helpers.file.typing_file_reader import TypeFileRea
 from nodeserver.wrapper.nodes.helpers.scene_manager import MirrorSceneManager
 from nodeserver.wrapper.nodes.node.base_nodes import NodeMirror, SlotMirror
 from nodeserver.wrapper.nodes.node.node_utils import NodeUtils
+from nodeserver.wrapper.utils.uuid_utils import IDGenerator
 
 logger = logging.getLogger("nds.instances")
 
@@ -171,12 +173,12 @@ class ServerInstance:
             self.state_controller.has_step_permission = False
 
         results = self._runtime.process_next(self._scene)
-        if results != None and self._send_callback != None:
+        if results != None:
             slot_results, node, came_from_cache = results
             result_data = self._prepare_to_send_output(node, slot_results)
             
             # if not came_from_cache:
-            self._send_callback(SrvNodeOutput(
+            self.send_to_client(SrvNodeOutput(
                 node_id=node._mirror.uid,
                 value=result_data
             ))
@@ -228,8 +230,8 @@ class ServerInstance:
             except queue.Empty:
                 break
             
-        if self._send_callback and action_statuses != {}:
-            self._send_callback(SrvSyncAction(
+        if action_statuses != {}:
+            self.send_to_client(SrvSyncAction(
                 action_statuses={
                     uid: status for uid, status in action_statuses.items()
                 }
@@ -251,6 +253,10 @@ class ServerInstance:
     def set_send_callback(self, callback: Callable[[ServerMessage], None]):
         self._send_callback = callback
 
+    def send_to_client(self, message: ServerMessage):
+        if self._send_callback:
+            self._send_callback(message)
+
     def _prepare_to_send_output(self, node: BaseNode, slot_results: dict[SlotMirror, SlotOutput] | None):
         result_data = {}
         if slot_results != None:
@@ -258,6 +264,7 @@ class ServerInstance:
                 result_data[slot.slot_name] = result.value
         
         return result_data
+
 
     def start_running(self):
         self.state_controller.queue_state(InstanceStates.RUNNING)
@@ -293,15 +300,16 @@ class ServerInstance:
 
 
     def _state_changed(self):
-        if not self._send_callback:
-            return
-        
-        
-        self._send_callback(SrvSyncState(
+        self.send_to_client(SrvSyncState(
             payload=SyncStatePayload(
                 loop_state=self.state_controller.loop_state,
                 instance_state=self.state_controller.instance_state
             )
+        ))
+        # FIXME: Testing notifications:
+        self.send_to_client(ServerNotification.notify(
+            message="State changed!",
+            level=NotificationLevel.INFO
         ))
 
 
@@ -330,6 +338,10 @@ class ServerInstance:
         )
 
         StateFileUtils.save_instance_state(state_data, instance_path)
+        self.send_to_client(ServerNotification.notify(
+            message="Instance saved.",
+            level=NotificationLevel.INFO
+        ))
         return state_data
 
     def load_internal_state(self, instance_path: str, node_state_path: str, state: InstanceState):
@@ -339,4 +351,8 @@ class ServerInstance:
             node_state = state.internal_states.nodes.get(node._mirror.uid)
             if node_state:
                 node.load_state(node_state_path, node_state)
-    
+
+                self.send_to_client(ServerNotification.notify(
+                    message="Loaded Internal State!",
+                    level=NotificationLevel.INFO,
+                ))

--- a/src/nodeserver/api/instance/server_instance.py
+++ b/src/nodeserver/api/instance/server_instance.py
@@ -9,7 +9,8 @@ from nodeserver.api.instance.instance_states import InstanceCommands, InstanceSt
 from nodeserver.api.internal.instance_state import InstanceState, InternalNodeState, InternalState, StateFileUtils
 from nodeserver.api.internal.internal_protocols import InstanceProtocol
 from nodeserver.api.web.requests.notification_requests import NotificationLevel, ServerNotification
-from nodeserver.api.web.requests.websocket_requests import ServerMessage, SrvNodeOutput, SrvSyncAction, SrvSyncState, SyncStatePayload
+from nodeserver.api.web.requests.request_unions import AnyServerMessage
+from nodeserver.api.web.requests.websocket_requests import SrvNodeOutput, SrvSyncAction, SrvSyncState, SyncStatePayload
 from nodeserver.api.web.websocket_protocol import ClientMessages, EditorActionStatus
 from nodeserver.api.instance.node_scene import NodeScene
 from nodeserver.wrapper.nodes.data.node_data_types import SuperSlotTypes
@@ -18,7 +19,6 @@ from nodeserver.wrapper.nodes.helpers.file.typing_file_reader import TypeFileRea
 from nodeserver.wrapper.nodes.helpers.scene_manager import MirrorSceneManager
 from nodeserver.wrapper.nodes.node.base_nodes import NodeMirror, SlotMirror
 from nodeserver.wrapper.nodes.node.node_utils import NodeUtils
-from nodeserver.wrapper.utils.uuid_utils import IDGenerator
 
 logger = logging.getLogger("nds.instances")
 
@@ -138,7 +138,7 @@ class ServerInstance:
     _created_at: float = 0
 
     _runtime: BaseServerRuntime
-    _send_callback: Callable[[ServerMessage], None] | None = None
+    _send_callback: Callable[[AnyServerMessage], None] | None = None
 
     state_controller: StateController
     action_controller: ActionController
@@ -258,10 +258,10 @@ class ServerInstance:
 
         return status
 
-    def set_send_callback(self, callback: Callable[[ServerMessage], None]):
+    def set_send_callback(self, callback: Callable[[AnyServerMessage], None]):
         self._send_callback = callback
 
-    def send_to_client(self, message: ServerMessage):
+    def send_to_client(self, message: AnyServerMessage):
         if self._send_callback:
             self._send_callback(message)
 

--- a/src/nodeserver/api/internal/internal_protocols.py
+++ b/src/nodeserver/api/internal/internal_protocols.py
@@ -10,7 +10,8 @@ class InstanceProtocol(Protocol):
     
     _attributed_id: str
 
-    _send_callback: Callable[[ServerMessage], None] | None = None
+    def send_to_client(self, message: ServerMessage) -> None:
+        pass
 
 
 class WorkspaceProtocol(Protocol):

--- a/src/nodeserver/api/internal/internal_protocols.py
+++ b/src/nodeserver/api/internal/internal_protocols.py
@@ -1,7 +1,7 @@
-from typing import Callable, Protocol
+from typing import Protocol
 
 from nodeserver.api.instance.node_scene import NodeScene
-from nodeserver.api.web.requests.websocket_requests import ServerMessage
+from nodeserver.api.web.requests.request_unions import AnyServerMessage
 from nodeserver.wrapper.nodes.helpers.scene_manager import MirrorSceneManager
 
 class InstanceProtocol(Protocol):
@@ -10,7 +10,7 @@ class InstanceProtocol(Protocol):
     
     _attributed_id: str
 
-    def send_to_client(self, message: ServerMessage) -> None:
+    def send_to_client(self, message: AnyServerMessage) -> None:
         pass
 
 

--- a/src/nodeserver/api/web/manager/websocket_handler.py
+++ b/src/nodeserver/api/web/manager/websocket_handler.py
@@ -8,13 +8,15 @@ import logging
 
 from nodeserver.api.instance.server_instance import ServerInstance
 from nodeserver.api.internal.instance_state import StateFileUtils
+from nodeserver.api.web.requests.notification_requests import ServerNotification
+from nodeserver.api.web.requests.request_unions import AnyServerMessage
+from nodeserver.api.web.requests.websocket_requests import SrvHandshakeError, SrvHandshakeSuccess
 from nodeserver.api.web.session.user_session import SessionUtils, UserSession
 from nodeserver.api.utils.url_routing import Endpoint, URLRouter
 from nodeserver.api.internal.instance_manager import InstanceManager
 
 from nodeserver.api.web.manager.session_manager import SessionManager
 from nodeserver.api.web.message_router import BaseMessagerouter
-from nodeserver.api.web.requests.websocket_requests import ServerMessage, SrvHandshakeError, SrvHandshakeSuccess
 from nodeserver.api.web.session.user_workspace import WorkspaceUtils
 from nodeserver.api.web.websocket_messages import MessageUtils
 from nodeserver.api.web.websocket_protocol import WebsocketStatus
@@ -96,8 +98,12 @@ class WebsocketHandler:
         if not instance or not session:
             return
 
-        def _thread_safe_send(data: ServerMessage) -> None:
+        def _thread_safe_send(data: AnyServerMessage) -> None:
             message = data.model_dump_json(by_alias=True)
+            # FIXME: This might not be fine
+            if isinstance(data, ServerNotification):
+                session.workspace.notification_controller.add_notification(data)
+
             if self.loop and self.loop.is_running():
                 asyncio.run_coroutine_threadsafe(
                     websocket.send_str(message), 
@@ -208,13 +214,15 @@ class WebsocketHandler:
                 except json.JSONDecodeError:
                     continue
     
-    async def _route_message(self, instance: ServerInstance, data: str) -> ServerMessage | None:
+    async def _route_message(self, instance: ServerInstance, data: str) -> AnyServerMessage | None:
         message = MessageUtils.parse_client_message(data)
+        session = self.session_manager.get_session_by_instance(instance._attributed_id)
+
         logger.info(f"Command Received: {message} for Instance '{instance._attributed_id}'")
-        if not message:
+        if not message or not session:
             return
         
-        output = self._router.route_message(message, instance)
+        output = self._router.route_message(message, instance, session)
         if output:
             logger.info(f"Sending route output to {instance} | output: {output.type}")
             logger.debug(f"Output Data: {output}")

--- a/src/nodeserver/api/web/message_router.py
+++ b/src/nodeserver/api/web/message_router.py
@@ -3,7 +3,10 @@ import json
 import logging
 
 from nodeserver.api.instance.actions.action_controller import Action
-from nodeserver.api.web.requests.websocket_requests import ServerMessage, SrvSyncScene
+from nodeserver.api.web.requests.notification_requests import ClientSyncNotifications, MsgUpdateNotification, ServerSyncNotifications
+from nodeserver.api.web.requests.request_unions import AnyServerMessage
+from nodeserver.api.web.requests.websocket_requests import SrvSyncScene
+from nodeserver.api.web.session.user_session import UserSession
 from nodeserver.api.web.websocket_messages import ClientMessageWrapper
 from nodeserver.api.web.requests.client_requests import MsgConnectionAction, MsgInstanceCommand, MsgInstanceState, MsgLoadScene, MsgLoopState, MsgNodeAction, MsgSimple
 from nodeserver.api.web.websocket_protocol import ClientMessages
@@ -11,7 +14,7 @@ from nodeserver.api.instance.server_instance import ServerInstance
 
 COMMAND_LOGGER = logging.getLogger("nds.commands")
 class BaseMessagerouter:
-    def route_message(self, message: ClientMessageWrapper, instance: ServerInstance) -> ServerMessage | None:
+    def route_message(self, message: ClientMessageWrapper, instance: ServerInstance, session: UserSession) -> AnyServerMessage | None:
         COMMAND_LOGGER.info(f"Routing command: {message.msg.type}")
 
         if isinstance(message.msg, MsgSimple):
@@ -20,6 +23,13 @@ class BaseMessagerouter:
                 return SrvSyncScene(
                     payload=scene_data
                 )
+            
+            if message.msg.type == ClientMessages.SYNC_NOTIFICATIONS:
+                notification_data = session.workspace.notification_controller.get_unread_notifications()
+                if len(notification_data) > 0:
+                    return ServerSyncNotifications(
+                        notifications=notification_data
+                    )
 
         elif isinstance(message.msg, MsgInstanceState):
             instance.state_controller.queue_state(message.msg.payload.state)
@@ -50,5 +60,8 @@ class BaseMessagerouter:
 
         elif isinstance(message.msg, MsgLoadScene):
             instance.load_new_scene(message.msg.payload)
+
+        elif isinstance(message.msg, MsgUpdateNotification):
+            session.workspace.notification_controller.update_notification(message.msg.payload)
 
         return None

--- a/src/nodeserver/api/web/requests/action_requests.py
+++ b/src/nodeserver/api/web/requests/action_requests.py
@@ -1,7 +1,7 @@
 from typing import List, Dict, Union, Literal, Annotated
 from pydantic import Field, TypeAdapter
 
-from nodeserver.api.web.requests.websocket_requests import BaseSocketModel
+from nodeserver.api.web.requests.base_requests import BaseSocketModel
 from nodeserver.api.web.websocket_protocol import SceneActionTypes
 from nodeserver.wrapper.nodes.helpers.file.node_scene_dataclasses import ConnectionSceneData, NodeSceneData
 

--- a/src/nodeserver/api/web/requests/base_requests.py
+++ b/src/nodeserver/api/web/requests/base_requests.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class BaseSocketModel(BaseModel):
+    model_config = ConfigDict(
+        use_enum_values=True,
+    )

--- a/src/nodeserver/api/web/requests/client_requests.py
+++ b/src/nodeserver/api/web/requests/client_requests.py
@@ -4,7 +4,7 @@ from pydantic import TypeAdapter
 
 from nodeserver.api.instance.instance_states import InstanceCommands, InstanceStates, LoopStates
 from nodeserver.api.web.requests.action_requests import ConnectionActionPayload, NodeActionPayload
-from nodeserver.api.web.requests.websocket_requests import BaseSocketModel
+from nodeserver.api.web.requests.base_requests import BaseSocketModel
 from nodeserver.api.web.websocket_protocol import ClientMessages
 from nodeserver.wrapper.nodes.helpers.file.node_scene_dataclasses import SceneData
 

--- a/src/nodeserver/api/web/requests/client_requests.py
+++ b/src/nodeserver/api/web/requests/client_requests.py
@@ -49,12 +49,10 @@ class MsgSimple(BaseSocketModel):
     type: Literal[ClientMessages.SYNC_CLIENT_SCENE]
 
 
-ClientCommand = Annotated[
+BaseClientCommands = Annotated[
     Union[
         MsgNodeAction, MsgConnectionAction, MsgInstanceState, 
         MsgLoopState, MsgLoadScene, MsgInstanceCommand, MsgSimple
     ],
     Field(discriminator="type")
 ]
-
-ClientCommandAdapter = TypeAdapter(ClientCommand)

--- a/src/nodeserver/api/web/requests/notification_requests.py
+++ b/src/nodeserver/api/web/requests/notification_requests.py
@@ -1,0 +1,89 @@
+from enum import Enum
+from typing import Any, Literal, Optional
+
+from pydantic import model_validator
+
+from nodeserver.api.web.requests.base_requests import BaseSocketModel
+from nodeserver.api.web.websocket_protocol import ServerMessages
+from nodeserver.wrapper.utils.uuid_utils import IDGenerator
+
+class NotificationLevel(str, Enum):
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+    DEBUG = "debug"
+
+class NotificationTarget(str, Enum):
+    NODE = "node"
+    SLOT = "slot"
+    PARAMETER = "param"
+
+    CONNECTION = "conn"
+    UNSPECIFIED = "unspecified"
+
+class ServerNotification(BaseSocketModel):
+    type: Literal[ServerMessages.NOTIFICATION] = ServerMessages.NOTIFICATION
+    uid: str
+    target: NotificationTarget = NotificationTarget.UNSPECIFIED
+    level: NotificationLevel
+
+    message: str 
+    extra_data: Optional[dict[str, Any]] = None
+    node_uid: Optional[str] = None
+    slot_name: Optional[str] = None
+    param_name: Optional[str] = None
+    conn_uid: Optional[str] = None
+
+    @classmethod 
+    def notify(cls, message: str, level: NotificationLevel, target: NotificationTarget = NotificationTarget.UNSPECIFIED, extra_data: Optional[dict[str, Any]] = None, **kwargs):
+        return cls(uid=IDGenerator.generate_notification_uid(),
+            level=level, target=target, message=message, extra_data=extra_data, **kwargs
+        )
+
+    @classmethod 
+    def node_notify(cls, node_uid: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.NODE, extra_data=extra_data, 
+            node_uid=node_uid
+        )
+    
+    @classmethod 
+    def slot_notify(cls, node_uid: str, slot_name: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.SLOT, extra_data=extra_data, 
+            node_uid=node_uid, slot_name=slot_name
+        )
+    
+    @classmethod 
+    def conn_notify(cls, conn_uid: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.CONNECTION, extra_data=extra_data, 
+            conn_uid=conn_uid
+        )
+    
+    @classmethod 
+    def param_notify(cls, node_uid: str, param_name: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.PARAMETER, extra_data=extra_data, 
+            node_uid=node_uid, param_name=param_name
+        )
+
+    @model_validator(mode='after')
+    def check_targets(self):
+        if self.target == NotificationTarget.SLOT:
+            if not self.node_uid or not self.slot_name:
+                raise ValueError("Slot notifications require node_uid and slot_name")
+        
+        elif self.target == NotificationTarget.PARAMETER:
+            if not self.node_uid or not self.param_name:
+                raise ValueError("Parameter notifications require node_uid and param_name")
+
+        elif self.target == NotificationTarget.NODE:
+            if not self.node_uid:
+                raise ValueError("Node notifications require node_uid")
+
+        elif self.target == NotificationTarget.CONNECTION:
+            if not self.conn_uid:
+                raise ValueError("Connection notifications require conn_uid")
+
+        return self
+
+class ServerSyncNotifications(BaseSocketModel):
+    type: Literal[ServerMessages.SYNC_NOTIFICATIONS] = ServerMessages.SYNC_NOTIFICATIONS
+    notifications: list[ServerNotification]

--- a/src/nodeserver/api/web/requests/notification_requests.py
+++ b/src/nodeserver/api/web/requests/notification_requests.py
@@ -27,7 +27,8 @@ class ServerNotification(BaseSocketModel):
     target: NotificationTarget = NotificationTarget.UNSPECIFIED
     level: NotificationLevel
 
-    message: str 
+    message: str
+    description: Optional[str] = None
     extra_data: Optional[dict[str, Any]] = None
     node_uid: Optional[str] = None
     slot_name: Optional[str] = None
@@ -35,32 +36,32 @@ class ServerNotification(BaseSocketModel):
     conn_uid: Optional[str] = None
 
     @classmethod 
-    def notify(cls, message: str, level: NotificationLevel, target: NotificationTarget = NotificationTarget.UNSPECIFIED, extra_data: Optional[dict[str, Any]] = None, **kwargs):
+    def notify(cls, message: str, level: NotificationLevel, target: NotificationTarget = NotificationTarget.UNSPECIFIED, extra_data: Optional[dict[str, Any]] = None, description: Optional[str] = None, **kwargs):
         return cls(uid=IDGenerator.generate_notification_uid(),
-            level=level, target=target, message=message, extra_data=extra_data, **kwargs
+            level=level, target=target, message=message, description=description, extra_data=extra_data, **kwargs
         )
 
     @classmethod 
-    def node_notify(cls, node_uid: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
-        return cls.notify(message, level, NotificationTarget.NODE, extra_data=extra_data, 
+    def node_notify(cls, node_uid: str, message: str, level: NotificationLevel, description: Optional[str] = None, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.NODE, description=description, extra_data=extra_data, 
             node_uid=node_uid
         )
     
     @classmethod 
-    def slot_notify(cls, node_uid: str, slot_name: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
-        return cls.notify(message, level, NotificationTarget.SLOT, extra_data=extra_data, 
+    def slot_notify(cls, node_uid: str, slot_name: str, message: str, level: NotificationLevel, description: Optional[str] = None, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.SLOT, description=description, extra_data=extra_data, 
             node_uid=node_uid, slot_name=slot_name
         )
     
     @classmethod 
-    def conn_notify(cls, conn_uid: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
-        return cls.notify(message, level, NotificationTarget.CONNECTION, extra_data=extra_data, 
+    def conn_notify(cls, conn_uid: str, message: str, level: NotificationLevel, description: Optional[str] = None, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.CONNECTION, description=description, extra_data=extra_data, 
             conn_uid=conn_uid
         )
     
     @classmethod 
-    def param_notify(cls, node_uid: str, param_name: str, message: str, level: NotificationLevel, extra_data: Optional[dict[str, Any]] = None):
-        return cls.notify(message, level, NotificationTarget.PARAMETER, extra_data=extra_data, 
+    def param_notify(cls, node_uid: str, param_name: str, message: str, level: NotificationLevel, description: Optional[str] = None, extra_data: Optional[dict[str, Any]] = None):
+        return cls.notify(message, level, NotificationTarget.PARAMETER, description=description, extra_data=extra_data, 
             node_uid=node_uid, param_name=param_name
         )
 

--- a/src/nodeserver/api/web/requests/notification_requests.py
+++ b/src/nodeserver/api/web/requests/notification_requests.py
@@ -1,10 +1,11 @@
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional, Union
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from nodeserver.api.web.requests.base_requests import BaseSocketModel
-from nodeserver.api.web.websocket_protocol import ServerMessages
+from nodeserver.api.web.requests.client_requests import MsgSimple
+from nodeserver.api.web.websocket_protocol import ClientMessages, ServerMessages
 from nodeserver.wrapper.utils.uuid_utils import IDGenerator
 
 class NotificationLevel(str, Enum):
@@ -85,6 +86,35 @@ class ServerNotification(BaseSocketModel):
 
         return self
 
+class NotificationWithMeta(ServerNotification):
+    uid: str
+    read: bool
+    timestamp: int
+
+# Server:
+
 class ServerSyncNotifications(BaseSocketModel):
     type: Literal[ServerMessages.SYNC_NOTIFICATIONS] = ServerMessages.SYNC_NOTIFICATIONS
     notifications: list[ServerNotification]
+
+ServerNotificationMessages = Annotated[
+    Union[
+        ServerSyncNotifications, ServerNotification
+    ],
+    Field(discriminator="type")
+]
+
+# Client:
+class MsgUpdateNotification(BaseSocketModel):
+    type: Literal[ClientMessages.UPDATE_NOTIFICATION]
+    payload: NotificationWithMeta
+
+class ClientSyncNotifications(MsgSimple):
+    type: Literal[ClientMessages.SYNC_NOTIFICATIONS]
+
+ClientNotificationMessages = Annotated[
+    Union[
+        MsgUpdateNotification, ClientSyncNotifications
+    ],
+    Field(discriminator="type")
+]

--- a/src/nodeserver/api/web/requests/request_unions.py
+++ b/src/nodeserver/api/web/requests/request_unions.py
@@ -1,0 +1,24 @@
+from typing import Annotated, Union
+
+from pydantic import Field, TypeAdapter
+
+from nodeserver.api.web.requests.client_requests import BaseClientCommands
+from nodeserver.api.web.requests.notification_requests import ClientNotificationMessages, ServerNotification, ServerNotificationMessages
+from nodeserver.api.web.requests.websocket_requests import BaseServerMessages
+
+
+AnyClientMessage = Annotated[
+    Union[
+        BaseClientCommands, ClientNotificationMessages
+    ],
+    Field(discriminator="type")
+]
+ClientMessageAdapter = TypeAdapter(AnyClientMessage)
+
+AnyServerMessage = Annotated[
+    Union[
+        BaseServerMessages, ServerNotificationMessages
+    ],
+    Field(discriminator="type")
+]
+ServerMessageAdapter = TypeAdapter(AnyServerMessage)

--- a/src/nodeserver/api/web/requests/websocket_requests.py
+++ b/src/nodeserver/api/web/requests/websocket_requests.py
@@ -1,13 +1,10 @@
 from typing import Annotated, Any, Dict, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 from nodeserver.api.instance.instance_states import InstanceStates, LoopStates
+from nodeserver.api.web.requests.base_requests import BaseSocketModel
+from nodeserver.api.web.requests.notification_requests import ServerNotification, ServerSyncNotifications
 from nodeserver.api.web.websocket_protocol import EditorActionStatus, ServerMessages, WebsocketStatus
 from nodeserver.wrapper.nodes.helpers.file.node_scene_dataclasses import SceneData
-
-class BaseSocketModel(BaseModel):
-    model_config = ConfigDict(
-        use_enum_values=True,
-    )
 
 
 class SyncStatePayload(BaseSocketModel):
@@ -54,7 +51,7 @@ HandshakeMessage = Annotated[
 ]
 
 ServerMessage = Annotated[
-    Union[HandshakeMessage, SrvSyncAction, SrvSyncScene, SrvSyncState, SrvNodeOutput, SrvSyncFiles],
+    Union[HandshakeMessage, ServerNotification, ServerSyncNotifications, SrvSyncAction, SrvSyncScene, SrvSyncState, SrvNodeOutput, SrvSyncFiles],
     Field(discriminator="type")
 ]
 

--- a/src/nodeserver/api/web/requests/websocket_requests.py
+++ b/src/nodeserver/api/web/requests/websocket_requests.py
@@ -1,8 +1,8 @@
 from typing import Annotated, Any, Dict, Literal, Optional, Union
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import Field
 from nodeserver.api.instance.instance_states import InstanceStates, LoopStates
 from nodeserver.api.web.requests.base_requests import BaseSocketModel
-from nodeserver.api.web.requests.notification_requests import ServerNotification, ServerSyncNotifications
+from nodeserver.api.web.requests.notification_requests import ServerSyncNotifications
 from nodeserver.api.web.websocket_protocol import EditorActionStatus, ServerMessages, WebsocketStatus
 from nodeserver.wrapper.nodes.helpers.file.node_scene_dataclasses import SceneData
 
@@ -50,9 +50,10 @@ HandshakeMessage = Annotated[
     Field(discriminator="status")
 ]
 
-ServerMessage = Annotated[
-    Union[HandshakeMessage, ServerNotification, ServerSyncNotifications, SrvSyncAction, SrvSyncScene, SrvSyncState, SrvNodeOutput, SrvSyncFiles],
+BaseServerMessages = Annotated[
+    Union[
+        HandshakeMessage,
+        ServerSyncNotifications, SrvSyncAction, SrvSyncScene, SrvSyncState, SrvNodeOutput, SrvSyncFiles
+    ],
     Field(discriminator="type")
 ]
-
-ServerMessageAdapter = TypeAdapter(ServerMessage)

--- a/src/nodeserver/api/web/session/user_notifications.py
+++ b/src/nodeserver/api/web/session/user_notifications.py
@@ -1,0 +1,29 @@
+
+from typing import Optional
+
+from nodeserver.api.internal.internal_protocols import InstanceProtocol
+from nodeserver.api.web.requests.notification_requests import NotificationWithMeta, ServerNotification
+
+
+class NotificationController:
+    instance: Optional[InstanceProtocol]
+    unread_notifications: dict[str, ServerNotification]
+
+    def __init__(self) -> None:
+        self.unread_notifications = {}
+
+    def add_notification(self, notification: ServerNotification):
+        if not self.unread_notifications.__contains__(notification.uid):
+            self.unread_notifications[notification.uid] = notification
+    
+    def _mark_as_read(self, notification_uid: str):
+        self.unread_notifications.pop(notification_uid, None)
+
+
+    def get_unread_notifications(self) -> list[ServerNotification]:
+        return list(self.unread_notifications.values())
+
+
+    def update_notification(self, msg_payload: NotificationWithMeta):
+        if msg_payload.read:
+            self._mark_as_read(msg_payload.uid)

--- a/src/nodeserver/api/web/session/user_workspace.py
+++ b/src/nodeserver/api/web/session/user_workspace.py
@@ -36,10 +36,7 @@ class UserWorkspace:
         if not self.current_instance:
             return False
 
-        if not self.current_instance._send_callback:
-            return False
-        
-        self.current_instance._send_callback(data)
+        self.current_instance.send_to_client(data)
         return True
 
     

--- a/src/nodeserver/api/web/session/user_workspace.py
+++ b/src/nodeserver/api/web/session/user_workspace.py
@@ -6,7 +6,8 @@ from typing import Optional
 from nodeserver.api.instance.server_instance import ServerInstance
 from nodeserver.api.internal.internal_protocols import InstanceProtocol
 from nodeserver.api.utils.workspace_utils import INSTANCE_FOLDER, UPLOADS_FOLDER, WorkspaceUtils
-from nodeserver.api.web.requests.websocket_requests import ServerMessage
+from nodeserver.api.web.requests.request_unions import AnyServerMessage
+from nodeserver.api.web.session.user_notifications import NotificationController
 
 logger = logging.getLogger("nds.workspace")
 
@@ -17,10 +18,13 @@ class UserWorkspace:
     
     instance_id: str | None = None
     current_instance: Optional[InstanceProtocol]
+
+    notification_controller: NotificationController
     
     def __init__(self, user_id: str) -> None:
         self.user_id = user_id
-    
+        self.notification_controller = NotificationController()
+
     @staticmethod
     def create(user_id: str) -> 'UserWorkspace':
         workspace = UserWorkspace(user_id)
@@ -31,8 +35,9 @@ class UserWorkspace:
     def assign_instance(self, instance: ServerInstance):
         self.instance_id = instance._attributed_id
         self.current_instance = instance
+        self.notification_controller.instance = self.current_instance
 
-    def send_msg_as_instance(self, data: ServerMessage) -> bool:
+    def send_msg_as_instance(self, data: AnyServerMessage) -> bool:
         if not self.current_instance:
             return False
 

--- a/src/nodeserver/api/web/websocket_messages.py
+++ b/src/nodeserver/api/web/websocket_messages.py
@@ -1,9 +1,9 @@
 import json
 from typing import Optional
-from nodeserver.api.web.requests.client_requests import ClientCommand, ClientCommandAdapter
-from nodeserver.api.web.requests.websocket_requests import ServerMessage
 
-class SocketMessage[MessageType: ServerMessage | ClientCommand]:
+from nodeserver.api.web.requests.request_unions import AnyClientMessage, AnyServerMessage, ClientMessageAdapter
+
+class SocketMessage[MessageType: AnyServerMessage | AnyClientMessage]:
     msg: MessageType
     raw_message: dict
 
@@ -16,12 +16,12 @@ class SocketMessage[MessageType: ServerMessage | ClientCommand]:
         return f"{self.__class__.__name__}({self.msg.type})"
         # return f"{self.__class__.__name__}({self.message.type.value}, payload_keys={list(self.message.payload.keys() if self.payload else [])})"
 
-class ServerMessageWrapper(SocketMessage[ServerMessage]): 
-    def __init__(self, raw_message: dict, message_data: ServerMessage) -> None:
+class ServerMessageWrapper(SocketMessage[AnyServerMessage]): 
+    def __init__(self, raw_message: dict, message_data: AnyServerMessage) -> None:
         super().__init__(raw_message, message_data)
 
-class ClientMessageWrapper(SocketMessage[ClientCommand]):
-    def __init__(self, raw_message: dict, message_data: ClientCommand) -> None:
+class ClientMessageWrapper(SocketMessage[AnyClientMessage]):
+    def __init__(self, raw_message: dict, message_data: AnyClientMessage) -> None:
         super().__init__(raw_message, message_data)
 
 
@@ -29,7 +29,7 @@ class MessageUtils:
     @staticmethod
     def parse_client_message(message_str: str) -> Optional[ClientMessageWrapper]:
         try:
-            command = ClientCommandAdapter.validate_json(message_str)
+            command = ClientMessageAdapter.validate_json(message_str)
             message_dict = json.loads(message_str)
             return ClientMessageWrapper(message_dict, command) 
         

--- a/src/nodeserver/api/web/websocket_protocol.py
+++ b/src/nodeserver/api/web/websocket_protocol.py
@@ -13,6 +13,9 @@ class ServerMessages(str, Enum):
     SYNC_ACTION = "sync_action"
     SYNC_FILES = "sync_files"
 
+    NOTIFICATION = "notification"
+    SYNC_NOTIFICATIONS = "sync_notifications"
+
 class ClientMessages(str, Enum):
     LOAD_SCENE = "LOAD_SCENE"
     SYNC_CLIENT_SCENE = "SYNC_CLIENT_SCENE"

--- a/src/nodeserver/api/web/websocket_protocol.py
+++ b/src/nodeserver/api/web/websocket_protocol.py
@@ -29,6 +29,9 @@ class ClientMessages(str, Enum):
 
     INSTANCE_COMMAND = "INSTANCE"
 
+    UPDATE_NOTIFICATION = "UPDATE_NOTIFICATION"
+    SYNC_NOTIFICATIONS = "SYNC_NOTIFICATIONS"
+
 class SceneActionTypes(str, Enum):
     ADD = "ADD"
     REMOVE = "REMOVE"

--- a/src/nodeserver/wrapper/utils/uuid_utils.py
+++ b/src/nodeserver/wrapper/utils/uuid_utils.py
@@ -8,6 +8,10 @@ class IDGenerator:
     @staticmethod
     def generate_node_id() -> str:
         return str(uuid.uuid4())
+    
+    @staticmethod
+    def generate_notification_uid() -> str:
+        return str(uuid.uuid4().hex[:4])
 
     @staticmethod
     def generate_conn_id() -> str:

--- a/tests/websocket_test.py
+++ b/tests/websocket_test.py
@@ -1,8 +1,5 @@
-import asyncio
-
 from nodeserver.api.base_server import NodeServer
 from nodeserver.api.instance.base_nodes import BaseNode
-from nodeserver.api.websocket_manager import WebsocketManager
 from nodeserver.wrapper.nodes.data.node_data import NodeData
 from nodeserver.wrapper.nodes.data.node_data_types import INPUT_TYPE, OUTPUT_TYPE, BaseSlotType, DataTypes, SuperSlotTypes
 from nodeserver.wrapper.nodes.helpers.file.type_dataclasses import BaseNodeParameter, NodeFileParameter, NodeNumberParameter, NodeParameterData, SlotData


### PR DESCRIPTION
## Changes:
+ Implemented the Notification System as requested on https://github.com/yDewolf/nodeblocks-server/issues/7
+ Refactored request unions (now on ``request_unions.py``) -> the other request files can just declare the requests and the union can be made in ``request_unions.py``

## Protocol Changes:
+ Added a ``notification`` server message;
+ Added a ``sync_notifications`` message for client (requests the sync) and for server (sends the notifications);
+ Added a ``update_notification`` client message;

## Future improvements (not on this PR):
+ Probably find a better way of handling notifications (see [websocket_handler.py line 104](https://github.com/yDewolf/nodeblocks-server/pull/9/changes#diff-6d90079e15907cda910508ded01334f84facc199f475d990897c3a2c870bb70dR104-R106))
+ Implement server notifications, like info and proper warnings.

## Related PRs:
- https://github.com/yDewolf/nodeblocks-editor/pull/12

## Related Issues:
+ https://github.com/yDewolf/nodeblocks-editor/issues/10
+ https://github.com/yDewolf/nodeblocks-server/issues/7